### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,6 +7,9 @@ on:
   pull_request_target:
     types:
       - labeled
+permissions:
+  contents: read
+  issues: write
 env:
   TARGET_REPO: github/cli
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/cli/security/code-scanning/4](https://github.com/whartondylan/cli/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow interacts with issues and pull requests, we will set `contents: read` and `issues: write` permissions. This ensures the workflow has only the necessary access to perform its tasks while adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow to apply to all jobs. This avoids redundancy and ensures consistent permissions across the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
