### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,9 @@ name: Python Package using Conda
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/internal/codespaces/portforwarder/port_forwarder.go
+++ b/internal/codespaces/portforwarder/port_forwarder.go
@@ -234,6 +234,11 @@ func (fwd *CodespacesPortForwarder) ListPorts(ctx context.Context) (ports []*tun
 
 // UpdatePortVisibility changes the visibility (private, org, public) of the specified port.
 func (fwd *CodespacesPortForwarder) UpdatePortVisibility(ctx context.Context, remotePort int, visibility string) error {
+	// Check if the remotePort is within the valid range for uint16
+	if remotePort < 0 || remotePort > 65535 {
+		return fmt.Errorf("invalid port number: %d (must be between 0 and 65535)", remotePort)
+	}
+
 	tunnelPort, err := fwd.connection.TunnelManager.GetTunnelPort(ctx, fwd.connection.Tunnel, remotePort, fwd.connection.Options)
 	if err != nil {
 		return fmt.Errorf("error getting tunnel port: %w", err)


### PR DESCRIPTION
Potential fix for [https://github.com/whartondylan/cli/security/code-scanning/1](https://github.com/whartondylan/cli/security/code-scanning/1)

To fix the issue, we need to ensure that the `remotePort` value is within the valid range for a `uint16` (0–65535) before performing the conversion. This can be achieved by adding explicit bounds checks in the `UpdatePortVisibility` function. If the value is out of bounds, the function should return an error.

#### Steps to implement the fix:
1. Add bounds checks for `remotePort` in the `UpdatePortVisibility` function to ensure it falls within the range of valid port numbers (0–65535).
2. Return an error if the bounds check fails, preventing the conversion and subsequent operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
